### PR TITLE
Add app build image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM google/cloud-sdk:slim
+
+RUN apt-get update && \
+	apt-get -y install kubectl
+
+RUN curl -LO \
+    https://get.helm.sh/helm-v2.16.3-linux-amd64.tar.gz \
+    && \
+    tar -zxvf helm-v2.16.3-linux-amd64.tar.gz \
+    && \
+    mv linux-amd64/helm /usr/local/bin/helm \
+    && rm -rf linux-amd64 \
+    && rm helm-*.tar.gz
+
+ENTRYPOINT ["/bin/bash"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,5 +11,3 @@ RUN curl -LO \
     mv linux-amd64/helm /usr/local/bin/helm \
     && rm -rf linux-amd64 \
     && rm helm-*.tar.gz
-
-ENTRYPOINT ["/bin/bash"]

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2020 Crown Copyright (Office for National Statistics)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,2 @@
+build:
+	docker build -t eq-app-deploy-image:latest .

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-# EQ Questionnaire Runner Deploy Image
-The Dockerfile used to build the EQ Questionnaire Runner base image.
+# EQ App Deploy Image
+The Dockerfile used to build a base image for deploying EQ containers with Helm.
 
 ## Building
 The image can be built using:
 
 ```sh
-docker build -t eq-questionnaire-runner-deploy-image:latest
+docker build -t eq-app-deploy-image:latest
 ```

--- a/README.md
+++ b/README.md
@@ -5,5 +5,5 @@ The Dockerfile used to build a base image for deploying EQ containers with Helm.
 The image can be built using:
 
 ```sh
-docker build -t eq-app-deploy-image:latest
+make build
 ```

--- a/README.md
+++ b/README.md
@@ -1,2 +1,9 @@
-# eq-questionnaire-runner-deploy-image
+# EQ Questionnaire Runner Deploy Image
 The Dockerfile used to build the EQ Questionnaire Runner base image.
+
+## Building
+The image can be built using:
+
+```sh
+docker build -t eq-questionnaire-runner-deploy-image:latest
+```


### PR DESCRIPTION
Added a Dockerfile to build the base app deploy image.

The initial approach is to have a repository per base image.

How to review
Either:
1. Run the container locally, exec into it and try to deploy an app using the installed Helm or
1. Use the (deploy_app)[https://github.com/ONSdigital/eq-questionnaire-runner/blob/master/ci/deploy_app.yaml] task in runner, switching the image used for this image. This is most easily done by pushing the image to a personal docker repository for testing or using the image `jgardiner/eq-app-deploy-image`