### PR TITLE
Update cloud-sdk image source

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM google/cloud-sdk:slim
+FROM gcr.io/google.com/cloudsdktool/cloud-sdk:slim
 
 RUN apt-get update && \
 	apt-get -y install kubectl


### PR DESCRIPTION
### What is the context of this PR?

Due to  [deprecation](https://hub.docker.com/r/google/cloud-sdk/), update image source from google/cloud-sdk:slim gcr.io/google.com/cloudsdktool/cloud-sdk:slim 

### How to review
Build the image and make sure it works