### PR TITLE
Fixing daily-benchmark run failure

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,12 @@
 FROM gcr.io/google.com/cloudsdktool/cloud-sdk:slim
 
 RUN apt-get update && \
-	apt-get -y install kubectl
+    apt-get install -y curl gnupg && \
+    echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
+    curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg  add - && \
+    apt-get update -y && \
+    apt-get install google-cloud-sdk-gke-gcloud-auth-plugin -y && \
+    apt-get -y install kubectl
 
 RUN curl -LO \
     https://get.helm.sh/helm-v3.1.2-linux-amd64.tar.gz \


### PR DESCRIPTION
### What is the context of this PR?
> A new kubectl plugin called “gke-gcloud-auth-plugin” is required starting with v1.26.
GKE users will need to download and use a separate authentication plugin to generate GKE-specific tokens. 
> - Hence changed the dockerfile to include the steps to include the kubectl plugin
[Trello](https://trello.com/c/xUdEeahu/5544-investigate-daily-benchmark-run-failure)

### How to review 
Describe the steps required to test the changes (include screenshots if appropriate).
> Tested on [sandbox](https://concourse.eq.gcp.onsdigital.uk/teams/development/pipelines/eq-sinhaa-benchmark) 