### PR TITLE
Update dockerfile to support Alpine for a slimmer base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,6 @@
 FROM gcr.io/google.com/cloudsdktool/cloud-sdk:alpine
 
-RUN apk --update add curl && \
-    apk add kubectl
-
-RUN curl -LO \
-    https://get.helm.sh/helm-v3.1.2-linux-amd64.tar.gz \
-    && \
-    tar -zxvf helm-v3.1.2-linux-amd64.tar.gz \
-    && \
-    mv linux-amd64/helm /usr/local/bin/helm \
-    && rm -rf linux-amd64 \
-    && rm helm-*.tar.gz
+RUN apk add && \
+    apk add kubectl && \
+    gcloud components install gke-gcloud-auth-plugin -q && \
+    rm /var/cache/apk/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,9 @@
 FROM gcr.io/google.com/cloudsdktool/cloud-sdk:alpine AS builder
 
 RUN apk --update add curl && \
-    apk add kubectl && \
-    gcloud components install gke-gcloud-auth-plugin && \
-    rm /var/cache/apk/*
-
-RUN curl -LO \
+    gcloud components install gke-gcloud-auth-plugin kubectl && \
+    rm /var/cache/apk/* && \
+    curl -LO \
     https://get.helm.sh/helm-v3.1.2-linux-amd64.tar.gz \
     && \
     tar -zxvf helm-v3.1.2-linux-amd64.tar.gz \
@@ -17,7 +15,6 @@ RUN curl -LO \
 FROM gcr.io/google.com/cloudsdktool/cloud-sdk:alpine
 
 COPY --from=builder google-cloud-sdk/bin/gke-gcloud-auth-plugin google-cloud-sdk/bin/gke-gcloud-auth-plugin
-COPY --from=builder google-cloud-sdk/bin/gcloud google-cloud-sdk/bin/gcloud
+COPY --from=builder google-cloud-sdk/bin/kubectl google-cloud-sdk/bin/kubectl
 COPY --from=builder /usr/local/bin/helm /usr/local/bin/helm
-COPY --from=builder /usr/bin/kubectl /usr/bin/kubectl
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,8 @@
-FROM gcr.io/google.com/cloudsdktool/cloud-sdk:alpine
+FROM gcr.io/google.com/cloudsdktool/cloud-sdk:alpine AS builder
 
 RUN apk --update add curl && \
     apk add kubectl && \
     gcloud components install gke-gcloud-auth-plugin && \
-    rm -rf google-cloud-sdk/platform && \
-    rm -rf google-cloud-sdk/bin/anthoscli && \
-    rm -rf google-cloud-sdk/.install && \
-    rm -rf google-cloud-sdk/data && \
-    rm -rf usr/local/libexec && \
-    rm -rf usr/local/bin/docker && \
     rm /var/cache/apk/*
 
 RUN curl -LO \
@@ -19,3 +13,11 @@ RUN curl -LO \
     mv linux-amd64/helm /usr/local/bin/helm \
     && rm -rf linux-amd64 \
     && rm helm-*.tar.gz
+
+FROM gcr.io/google.com/cloudsdktool/cloud-sdk:alpine
+
+COPY --from=builder google-cloud-sdk/bin/gke-gcloud-auth-plugin google-cloud-sdk/bin/gke-gcloud-auth-plugin
+COPY --from=builder google-cloud-sdk/bin/gcloud google-cloud-sdk/bin/gcloud
+COPY --from=builder /usr/local/bin/helm /usr/local/bin/helm
+COPY --from=builder /usr/bin/kubectl /usr/bin/kubectl
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,7 @@
-FROM gcr.io/google.com/cloudsdktool/cloud-sdk:slim
+FROM gcr.io/google.com/cloudsdktool/cloud-sdk:alpine
 
-RUN apt-get update && \
-    apt-get install -y curl gnupg && \
-    echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
-    curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg  add - && \
-    apt-get update -y && \
-    apt-get install google-cloud-sdk-gke-gcloud-auth-plugin -y && \
-    apt-get -y install kubectl
+RUN apk --update add curl && \
+    apk add kubectl
 
 RUN curl -LO \
     https://get.helm.sh/helm-v3.1.2-linux-amd64.tar.gz \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,21 @@
 FROM gcr.io/google.com/cloudsdktool/cloud-sdk:alpine
 
-RUN apk add && \
+RUN apk --update add curl && \
     apk add kubectl && \
-    gcloud components install gke-gcloud-auth-plugin -q && \
+    gcloud components install gke-gcloud-auth-plugin && \
+    rm -rf google-cloud-sdk/platform && \
+    rm -rf google-cloud-sdk/bin/anthoscli && \
+    rm -rf google-cloud-sdk/.install && \
+    rm -rf google-cloud-sdk/data && \
+    rm -rf usr/local/libexec && \
+    rm -rf usr/local/bin/docker && \
     rm /var/cache/apk/*
+
+RUN curl -LO \
+    https://get.helm.sh/helm-v3.1.2-linux-amd64.tar.gz \
+    && \
+    tar -zxvf helm-v3.1.2-linux-amd64.tar.gz \
+    && \
+    mv linux-amd64/helm /usr/local/bin/helm \
+    && rm -rf linux-amd64 \
+    && rm helm-*.tar.gz

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,30 @@
 FROM gcr.io/google.com/cloudsdktool/cloud-sdk:alpine AS builder
 
-RUN apk --update add curl && \
+# Install gcloud auth plugin, kubectl and helm
+RUN apk --update --no-cache add curl && \
     gcloud components install gke-gcloud-auth-plugin kubectl && \
-    rm /var/cache/apk/* && \
-    curl -LO \
-    https://get.helm.sh/helm-v3.1.2-linux-amd64.tar.gz \
-    && \
-    tar -zxvf helm-v3.1.2-linux-amd64.tar.gz \
-    && \
-    mv linux-amd64/helm /usr/local/bin/helm \
-    && rm -rf linux-amd64 \
-    && rm helm-*.tar.gz
+    curl -LO https://get.helm.sh/helm-v3.1.2-linux-amd64.tar.gz && \
+    tar -zxvf helm-v3.1.2-linux-amd64.tar.gz
 
-FROM gcr.io/google.com/cloudsdktool/cloud-sdk:alpine
+FROM alpine:3.19
 
+# Add gcloud to the path
+ENV PATH /google-cloud-sdk/bin:$PATH
+
+# Install dependencies
+RUN apk add --no-cache python3 bash jq
+
+# Copy binaries from the builder
+COPY --from=builder google-cloud-sdk/lib /google-cloud-sdk/lib
 COPY --from=builder google-cloud-sdk/bin/gke-gcloud-auth-plugin google-cloud-sdk/bin/gke-gcloud-auth-plugin
+COPY --from=builder google-cloud-sdk/bin/gcloud google-cloud-sdk/bin/gcloud
 COPY --from=builder google-cloud-sdk/bin/kubectl google-cloud-sdk/bin/kubectl
-COPY --from=builder /usr/local/bin/helm /usr/local/bin/helm
+COPY --from=builder linux-amd64/helm /usr/local/bin/helm
 
+# Update gcloud config
+RUN gcloud config set core/disable_usage_reporting true && \
+    gcloud config set component_manager/disable_update_check true && \
+    gcloud config set metrics/environment github_docker_image
+
+# Set the default configuration directory
+VOLUME ["/root/.config"]


### PR DESCRIPTION
### What is the context of this PR?
To create a slimmer base image, we had to change from using `slim` to `alpine` because it built an image with a smaller virtual size than the current image. Using `slim`, the image that built had a larger virtual size than the current.  

In order for Alpine to be used, Debian-based commands (apt) had to be replaced with Alpine commands (apk). Some commands were also removed as they were considered to not be necessary. (Note:`apt-key` is also deprecated).

### How to review
- Ensure the changes made are correct
- Check if the removed commands are needed
